### PR TITLE
fix: Improve title visibility and swap button colors

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -57,10 +57,19 @@ body {
 h1 {
     font-size: var(--font-size-xxl);
     font-weight: 700;
+    color: var(--light); /* Fallback color for browsers that don't support background-clip */
     background: linear-gradient(90deg, var(--light), #b39ddb);
     -webkit-background-clip: text;
     background-clip: text;
-    color: transparent;
+    -webkit-text-fill-color: transparent;
+}
+
+/* Fallback for browsers that don't support background-clip: text */
+@supports not (background-clip: text) {
+    h1 {
+        background: none;
+        color: var(--light);
+    }
 }
 
 .subtitle {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -70,11 +70,21 @@
 }
 
 .btn-download-fav {
+    background: #ff9800;
+    box-shadow: 0 4px 15px rgba(255, 152, 0, 0.2);
+}
+
+.btn-download-fav:hover {
+    background: #f57c00;
+    box-shadow: 0 6px 20px rgba(255, 152, 0, 0.3);
+}
+
+.btn-delete-non-fav {
     background: #e91e63;
     box-shadow: 0 4px 15px rgba(233, 30, 99, 0.2);
 }
 
-.btn-download-fav:hover {
+.btn-delete-non-fav:hover {
     background: #c2185b;
     box-shadow: 0 6px 20px rgba(233, 30, 99, 0.3);
 }


### PR DESCRIPTION
Title visibility fixes:
- Add fallback color for h1 title to prevent invisible text
- Use -webkit-text-fill-color: transparent for better browser support
- Add @supports fallback for browsers without background-clip: text support
- Ensures title is always visible even if gradient background-clip fails

Button color swap:
- Change download favorites button from pink to orange (#ff9800)
- Change delete non-favorites button from default to pink (#e91e63)
- Improves visual distinction between destructive and non-destructive actions
- Orange for download (positive action), pink for delete (caution action)